### PR TITLE
Fixes/author attribution on post

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -35,29 +35,32 @@ post_class: post-template
         {% endif %}
 
         <footer class="post-footer">
-            <!-- If we want to display author's name and bio -->
-            {% if site.author %}
-                <figure class="author-image">
-                    <a class="img" href="{{ site.baseurl }}" style="background-image: url({{ site.baseurl }}/assets/images/profile.png)">
-                    <span class="hidden">{{site.author}}'s Picture</span></a>
-                </figure>
-                <section class="author">
-                    <!-- Author Name -->
-                    <h4> {{ site.author }} </h4>
-                    <!-- Author Bio -->
-                    <p>
-                        We are the Lean Software Boutique. Check us out at <a href="http://www.ombulabs.com">www.ombulabs.com</a>
-                    </p>
-                </section>
-            {% endif %}
+          {% if page.author %}
+            {% assign author = site.authors[page.author] %}
+            <figure class="author-image">
+              {% if author.gravatar %}
+                <a class="img" href="{{ page.baseurl }}" style="background-image: url(http://2.gravatar.com/avatar/{{ author.gravatar }}?s=50)">
+                <span class="hidden">{{author.display_name}}'s Picture</span></a>
+              {% else %}
+                <a class="img" href="{{ page.baseurl }}" style="background-image: url({{ page.baseurl }}/assets/images/profile.png)">
+                <span class="hidden"></span></a>
+              {% endif %}
+            </figure>
+            <section class="author">
+              <h4> {{ author.display_name }} </h4>
+              <p>
+                We are the Lean Software Boutique. Check us out at <a href="http://www.ombulabs.com">www.ombulabs.com</a>
+              </p>
+            </section>
+          {% endif %}
 
-            <!-- Share links section -->
-            {% include share.html %}
+          <!-- Share links section -->
+          {% include share.html %}
 
-            <!-- Disqus comments -->
-            {% if page.disqus %}
-              {% include disqus.html %}
-            {% endif %}
+          <!-- Disqus comments -->
+          {% if page.disqus %}
+            {% include disqus.html %}
+          {% endif %}
 
         </footer>
 

--- a/_site/git/github/4-useful-github-tricks.html
+++ b/_site/git/github/4-useful-github-tricks.html
@@ -85,24 +85,24 @@
         
 
         <footer class="post-footer">
-            <!-- If we want to display author's name and bio -->
+          
             
-                <figure class="author-image">
-                    <a class="img" href="/blog" style="background-image: url(/blog/assets/images/profile.png)">
-                    <span class="hidden">Ombulabs's Picture</span></a>
-                </figure>
-                <section class="author">
-                    <!-- Author Name -->
-                    <h4> Ombulabs </h4>
-                    <!-- Author Bio -->
-                    <p>
-                        We are the Lean Software Boutique. Check us out at <a href="http://www.ombulabs.com">www.ombulabs.com</a>
-                    </p>
-                </section>
-            
+            <figure class="author-image">
+              
+                <a class="img" href="" style="background-image: url(http://2.gravatar.com/avatar/350875eb8fce8553e12040c5a1f5d5d0?s=50)">
+                <span class="hidden">Mauro Otonelli's Picture</span></a>
+              
+            </figure>
+            <section class="author">
+              <h4> Mauro Otonelli </h4>
+              <p>
+                We are the Lean Software Boutique. Check us out at <a href="http://www.ombulabs.com">www.ombulabs.com</a>
+              </p>
+            </section>
+          
 
-            <!-- Share links section -->
-            <section class="share">
+          <!-- Share links section -->
+          <section class="share">
     <h4>Share this post</h4>
     <a class="icon-twitter" href="http://twitter.com/share?text=4 Useful Github tricks which should be more popular&amp;url=http://www.ombulabs.com/git/github/4-useful-github-tricks.html"
         onclick="window.open(this.href, 'twitter-share', 'width=550,height=235');return false;">
@@ -118,9 +118,9 @@
     </a>
 </section>
 
-            <!-- Disqus comments -->
-            
-              <section class="disqus">
+          <!-- Disqus comments -->
+          
+            <section class="disqus">
     <div id="disqus_thread"></div>
     <script type="text/javascript">
 
@@ -136,7 +136,7 @@
     <a href="http://disqus.com" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a>
 </section>
 
-            
+          
 
         </footer>
 

--- a/_site/git/github/how-to-git-push-with-blocked-ports.html
+++ b/_site/git/github/how-to-git-push-with-blocked-ports.html
@@ -77,24 +77,24 @@ Everything up-to-date
         
 
         <footer class="post-footer">
-            <!-- If we want to display author's name and bio -->
+          
             
-                <figure class="author-image">
-                    <a class="img" href="/blog" style="background-image: url(/blog/assets/images/profile.png)">
-                    <span class="hidden">Ombulabs's Picture</span></a>
-                </figure>
-                <section class="author">
-                    <!-- Author Name -->
-                    <h4> Ombulabs </h4>
-                    <!-- Author Bio -->
-                    <p>
-                        We are the Lean Software Boutique. Check us out at <a href="http://www.ombulabs.com">www.ombulabs.com</a>
-                    </p>
-                </section>
-            
+            <figure class="author-image">
+              
+                <a class="img" href="" style="background-image: url(http://2.gravatar.com/avatar/9299203e7e9b9ae35e39eb66f3155f15?s=50)">
+                <span class="hidden">Ernesto Tagwerker's Picture</span></a>
+              
+            </figure>
+            <section class="author">
+              <h4> Ernesto Tagwerker </h4>
+              <p>
+                We are the Lean Software Boutique. Check us out at <a href="http://www.ombulabs.com">www.ombulabs.com</a>
+              </p>
+            </section>
+          
 
-            <!-- Share links section -->
-            <section class="share">
+          <!-- Share links section -->
+          <section class="share">
     <h4>Share this post</h4>
     <a class="icon-twitter" href="http://twitter.com/share?text=How to Git push with blocked ports&amp;url=http://www.ombulabs.com/git/github/how-to-git-push-with-blocked-ports.html"
         onclick="window.open(this.href, 'twitter-share', 'width=550,height=235');return false;">
@@ -110,9 +110,9 @@ Everything up-to-date
     </a>
 </section>
 
-            <!-- Disqus comments -->
-            
-              <section class="disqus">
+          <!-- Disqus comments -->
+          
+            <section class="disqus">
     <div id="disqus_thread"></div>
     <script type="text/javascript">
 
@@ -128,7 +128,7 @@ Everything up-to-date
     <a href="http://disqus.com" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a>
 </section>
 
-            
+          
 
         </footer>
 

--- a/_site/lean-startup/the-lean-startup-way.html
+++ b/_site/lean-startup/the-lean-startup-way.html
@@ -89,24 +89,24 @@
         
 
         <footer class="post-footer">
-            <!-- If we want to display author's name and bio -->
+          
             
-                <figure class="author-image">
-                    <a class="img" href="/blog" style="background-image: url(/blog/assets/images/profile.png)">
-                    <span class="hidden">Ombulabs's Picture</span></a>
-                </figure>
-                <section class="author">
-                    <!-- Author Name -->
-                    <h4> Ombulabs </h4>
-                    <!-- Author Bio -->
-                    <p>
-                        We are the Lean Software Boutique. Check us out at <a href="http://www.ombulabs.com">www.ombulabs.com</a>
-                    </p>
-                </section>
-            
+            <figure class="author-image">
+              
+                <a class="img" href="" style="background-image: url(http://2.gravatar.com/avatar/9299203e7e9b9ae35e39eb66f3155f15?s=50)">
+                <span class="hidden">Ernesto Tagwerker's Picture</span></a>
+              
+            </figure>
+            <section class="author">
+              <h4> Ernesto Tagwerker </h4>
+              <p>
+                We are the Lean Software Boutique. Check us out at <a href="http://www.ombulabs.com">www.ombulabs.com</a>
+              </p>
+            </section>
+          
 
-            <!-- Share links section -->
-            <section class="share">
+          <!-- Share links section -->
+          <section class="share">
     <h4>Share this post</h4>
     <a class="icon-twitter" href="http://twitter.com/share?text=The Lean Startup Way&amp;url=http://www.ombulabs.com/lean-startup/the-lean-startup-way.html"
         onclick="window.open(this.href, 'twitter-share', 'width=550,height=235');return false;">
@@ -122,9 +122,9 @@
     </a>
 </section>
 
-            <!-- Disqus comments -->
-            
-              <section class="disqus">
+          <!-- Disqus comments -->
+          
+            <section class="disqus">
     <div id="disqus_thread"></div>
     <script type="text/javascript">
 
@@ -140,7 +140,7 @@
     <a href="http://disqus.com" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a>
 </section>
 
-            
+          
 
         </footer>
 

--- a/_site/ruby/benchmark/enumerator-grep-vs-enumerator-select.html
+++ b/_site/ruby/benchmark/enumerator-grep-vs-enumerator-select.html
@@ -103,24 +103,24 @@ as <code>#map</code> does and reads very nicely. For example:</p>
         
 
         <footer class="post-footer">
-            <!-- If we want to display author's name and bio -->
+          
             
-                <figure class="author-image">
-                    <a class="img" href="/blog" style="background-image: url(/blog/assets/images/profile.png)">
-                    <span class="hidden">Ombulabs's Picture</span></a>
-                </figure>
-                <section class="author">
-                    <!-- Author Name -->
-                    <h4> Ombulabs </h4>
-                    <!-- Author Bio -->
-                    <p>
-                        We are the Lean Software Boutique. Check us out at <a href="http://www.ombulabs.com">www.ombulabs.com</a>
-                    </p>
-                </section>
-            
+            <figure class="author-image">
+              
+                <a class="img" href="" style="background-image: url(http://2.gravatar.com/avatar/350875eb8fce8553e12040c5a1f5d5d0?s=50)">
+                <span class="hidden">Mauro Otonelli's Picture</span></a>
+              
+            </figure>
+            <section class="author">
+              <h4> Mauro Otonelli </h4>
+              <p>
+                We are the Lean Software Boutique. Check us out at <a href="http://www.ombulabs.com">www.ombulabs.com</a>
+              </p>
+            </section>
+          
 
-            <!-- Share links section -->
-            <section class="share">
+          <!-- Share links section -->
+          <section class="share">
     <h4>Share this post</h4>
     <a class="icon-twitter" href="http://twitter.com/share?text=Enumerable#grep vs Enumerable#select&amp;url=http://www.ombulabs.com/ruby/benchmark/enumerator-grep-vs-enumerator-select.html"
         onclick="window.open(this.href, 'twitter-share', 'width=550,height=235');return false;">
@@ -136,9 +136,9 @@ as <code>#map</code> does and reads very nicely. For example:</p>
     </a>
 </section>
 
-            <!-- Disqus comments -->
-            
-              <section class="disqus">
+          <!-- Disqus comments -->
+          
+            <section class="disqus">
     <div id="disqus_thread"></div>
     <script type="text/javascript">
 
@@ -154,7 +154,7 @@ as <code>#map</code> does and reads very nicely. For example:</p>
     <a href="http://disqus.com" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a>
 </section>
 
-            
+          
 
         </footer>
 

--- a/_site/security/mercado-pago-security-vulnerability.html
+++ b/_site/security/mercado-pago-security-vulnerability.html
@@ -208,24 +208,24 @@
         
 
         <footer class="post-footer">
-            <!-- If we want to display author's name and bio -->
+          
             
-                <figure class="author-image">
-                    <a class="img" href="/blog" style="background-image: url(/blog/assets/images/profile.png)">
-                    <span class="hidden">Ombulabs's Picture</span></a>
-                </figure>
-                <section class="author">
-                    <!-- Author Name -->
-                    <h4> Ombulabs </h4>
-                    <!-- Author Bio -->
-                    <p>
-                        We are the Lean Software Boutique. Check us out at <a href="http://www.ombulabs.com">www.ombulabs.com</a>
-                    </p>
-                </section>
-            
+            <figure class="author-image">
+              
+                <a class="img" href="" style="background-image: url(http://2.gravatar.com/avatar/9299203e7e9b9ae35e39eb66f3155f15?s=50)">
+                <span class="hidden">Ernesto Tagwerker's Picture</span></a>
+              
+            </figure>
+            <section class="author">
+              <h4> Ernesto Tagwerker </h4>
+              <p>
+                We are the Lean Software Boutique. Check us out at <a href="http://www.ombulabs.com">www.ombulabs.com</a>
+              </p>
+            </section>
+          
 
-            <!-- Share links section -->
-            <section class="share">
+          <!-- Share links section -->
+          <section class="share">
     <h4>Share this post</h4>
     <a class="icon-twitter" href="http://twitter.com/share?text=Mercado Pago Security Hole&amp;url=http://www.ombulabs.com/security/mercado-pago-security-vulnerability.html"
         onclick="window.open(this.href, 'twitter-share', 'width=550,height=235');return false;">
@@ -241,9 +241,9 @@
     </a>
 </section>
 
-            <!-- Disqus comments -->
-            
-              <section class="disqus">
+          <!-- Disqus comments -->
+          
+            <section class="disqus">
     <div id="disqus_thread"></div>
     <script type="text/javascript">
 
@@ -259,7 +259,7 @@
     <a href="http://disqus.com" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a>
 </section>
 
-            
+          
 
         </footer>
 

--- a/_site/software-development/software-quality/our-definition-of-done.html
+++ b/_site/software-development/software-quality/our-definition-of-done.html
@@ -79,24 +79,24 @@
         
 
         <footer class="post-footer">
-            <!-- If we want to display author's name and bio -->
+          
             
-                <figure class="author-image">
-                    <a class="img" href="/blog" style="background-image: url(/blog/assets/images/profile.png)">
-                    <span class="hidden">Ombulabs's Picture</span></a>
-                </figure>
-                <section class="author">
-                    <!-- Author Name -->
-                    <h4> Ombulabs </h4>
-                    <!-- Author Bio -->
-                    <p>
-                        We are the Lean Software Boutique. Check us out at <a href="http://www.ombulabs.com">www.ombulabs.com</a>
-                    </p>
-                </section>
-            
+            <figure class="author-image">
+              
+                <a class="img" href="" style="background-image: url(http://2.gravatar.com/avatar/9299203e7e9b9ae35e39eb66f3155f15?s=50)">
+                <span class="hidden">Ernesto Tagwerker's Picture</span></a>
+              
+            </figure>
+            <section class="author">
+              <h4> Ernesto Tagwerker </h4>
+              <p>
+                We are the Lean Software Boutique. Check us out at <a href="http://www.ombulabs.com">www.ombulabs.com</a>
+              </p>
+            </section>
+          
 
-            <!-- Share links section -->
-            <section class="share">
+          <!-- Share links section -->
+          <section class="share">
     <h4>Share this post</h4>
     <a class="icon-twitter" href="http://twitter.com/share?text=Our Definition of "Done"&amp;url=http://www.ombulabs.com/software-development/software-quality/our-definition-of-done.html"
         onclick="window.open(this.href, 'twitter-share', 'width=550,height=235');return false;">
@@ -112,9 +112,9 @@
     </a>
 </section>
 
-            <!-- Disqus comments -->
-            
-              <section class="disqus">
+          <!-- Disqus comments -->
+          
+            <section class="disqus">
     <div id="disqus_thread"></div>
     <script type="text/javascript">
 
@@ -130,7 +130,7 @@
     <a href="http://disqus.com" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a>
 </section>
 
-            
+          
 
         </footer>
 

--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -342,7 +342,7 @@ pre {
     width: 100%;
     padding: 10px;
     font-family: Inconsolata, monospace, sans-serif;
-    font-size: 0.9em;
+    font-size: 0.8em;
     white-space: pre;
     overflow: auto;
     background: #F7FAFB;


### PR DESCRIPTION
Hey @etagwerker, 

This PR adds author attribution to the footer for each post. I also reduced the font-size for the code syntax by 0.1em, as I thought it was too big and almost the same size as the main content's font-size. 

Let me know if I should change the tagline for "We are the lean software.." to a bio or something else. 

Please check it out, thanks! 