### PR TITLE
Mauro oto/add html proofer for 404 links

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,4 +20,5 @@ group :development do
   gem 'pry'
   gem 'pry-byebug'
   gem 'byebug'
+  gem 'html-proofer'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,17 +1,38 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (5.0.0.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (~> 0.7)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    addressable (2.5.0)
+      public_suffix (~> 2.0, >= 2.0.2)
     builder (3.2.2)
     byebug (8.2.2)
     coderay (1.1.0)
     colorator (0.1)
+    colored (1.2)
+    concurrent-ruby (1.0.2)
     daemons (1.2.3)
     dotenv (2.1.0)
+    ethon (0.9.1)
+      ffi (>= 1.3.0)
     eventmachine (1.0.9.1)
     ffi (1.9.10)
     foreman (0.78.0)
       thor (~> 0.19.1)
     git-version-bump (0.15.1)
+    html-proofer (3.3.1)
+      activesupport (>= 4.2, < 6.0)
+      addressable (~> 2.3)
+      colored (~> 1.2)
+      mercenary (~> 0.3.2)
+      nokogiri (~> 1.5)
+      parallel (~> 1.3)
+      typhoeus (~> 0.7)
+      yell (~> 2.0)
+    i18n (0.7.0)
     jekyll (3.1.2)
       colorator (~> 0.1)
       jekyll-sass-converter (~> 1.0)
@@ -39,6 +60,11 @@ GEM
       rb-inotify (>= 0.9.7)
     mercenary (0.3.6)
     method_source (0.8.2)
+    mini_portile2 (2.1.0)
+    minitest (5.9.1)
+    nokogiri (1.6.8.1)
+      mini_portile2 (~> 2.1.0)
+    parallel (1.9.0)
     posix-spawn (0.3.9)
     pry (0.10.3)
       coderay (~> 1.1.0)
@@ -47,6 +73,7 @@ GEM
     pry-byebug (3.3.0)
       byebug (~> 8.0)
       pry (~> 0.10)
+    public_suffix (2.0.4)
     pygments.rb (0.6.0)
       posix-spawn (~> 0.3.6)
       yajl-ruby (~> 1.1.0)
@@ -70,8 +97,14 @@ GEM
       eventmachine (~> 1.0, >= 1.0.4)
       rack (~> 1.0)
     thor (0.19.1)
+    thread_safe (0.3.5)
     titleize (1.4.0)
+    typhoeus (0.8.0)
+      ethon (>= 0.8.0)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
     yajl-ruby (1.1.0)
+    yell (2.0.7)
 
 PLATFORMS
   ruby
@@ -80,6 +113,7 @@ DEPENDENCIES
   byebug
   dotenv
   foreman
+  html-proofer
   jekyll (~> 3.0)
   jekyll-authors
   jekyll-categories
@@ -95,4 +129,4 @@ DEPENDENCIES
   thin
 
 BUNDLED WITH
-   1.12.1
+   1.13.6

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,1 @@
+Dir.glob('lib/tasks/*.rake').each { |r| import r }

--- a/lib/tasks/utils.rake
+++ b/lib/tasks/utils.rake
@@ -1,4 +1,9 @@
+require 'html-proofer'
+
 task :find_dead_links do
-  cmd = 'htmlproofer ./_site --only-4xx --url-ignore "/blog/,/#content/"'
-  system("bundle exec #{cmd}")
+  opts = { only_4xx: true, url_ignore: [/blog/, /#content/] }
+  begin
+    HTMLProofer.check_directory("./_site", opts).run
+  rescue => e
+  end
 end

--- a/lib/tasks/utils.rake
+++ b/lib/tasks/utils.rake
@@ -1,0 +1,4 @@
+task :find_dead_links do
+  cmd = 'htmlproofer ./_site --only-4xx --url-ignore "/blog/,/#content/"'
+  system("bundle exec #{cmd}")
+end


### PR DESCRIPTION
Hey @etagwerker, @lubc, 

This PR adds the html proofer gem for finding 404 links using a Rake task. 

Please check it out, thanks! 